### PR TITLE
fix(runfiles): support bzlmod repo mappings

### DIFF
--- a/packages/runfiles/paths.ts
+++ b/packages/runfiles/paths.ts
@@ -1,3 +1,7 @@
 // NB: on windows thanks to legacy 8-character path segments it might be like
 // c:/b/ojvxx6nx/execroot/build_~1/bazel-~1/x64_wi~1/bin/internal/npm_in~1/test
 export const BAZEL_OUT_REGEX = /(\/bazel-out\/|\/bazel-~1\/x64_wi~1\/)/;
+
+// The runfiles root symlink under which the repository mapping can be found.
+// https://cs.opensource.google/bazel/bazel/+/1b073ac0a719a09c9b2d1a52680517ab22dc971e:src/main/java/com/google/devtools/build/lib/analysis/Runfiles.java;l=424
+export const REPO_MAPPING_RLOCATION = '_repo_mapping';

--- a/packages/runfiles/repository.ts
+++ b/packages/runfiles/repository.ts
@@ -1,0 +1,43 @@
+/**
+ * Utils for managing repository mappings.
+ *
+ * The majority of this code is ported from [rules_go](https://github.com/bazelbuild/rules_go/pull/3347).
+ */
+
+export interface RepoMappings {
+  [sourceRepo: string]: {
+    [targetRepoApparentName: string]: string;
+  };
+}
+
+const legacyExternalGeneratedFile =
+  /\/_main\/bazel-out\/[^/]+\/bin\/external\/([^/]+)\//;
+const legacyExternalFile = /\/_main\/external\/([^/]+)\//;
+
+// CurrentRepository returns the canonical name of the Bazel repository that
+// contains the source file of the caller of CurrentRepository.
+export function currentRepository(): string {
+  return callerRepositoryFromStack(1);
+}
+
+// CallerRepository returns the canonical name of the Bazel repository that
+// contains the source file of the caller of the function that itself calls
+// CallerRepository.
+export function callerRepository(): string {
+  return callerRepositoryFromStack(2);
+}
+
+export function callerRepositoryFromStack(skip: number): string {
+  const stack = new Error().stack.split("\n");
+  const file = stack[skip + 2]; // 0 is the Error(msg), 1 is this method, 2 is the caller
+  const match =
+    file.match(legacyExternalGeneratedFile) || file.match(legacyExternalFile);
+
+  // If a file is not in an external repository, it is in the main repository,
+  // which has the empty string as its canonical name.
+  if (!match || match[0] == "_main") {
+    return "";
+  }
+
+  return match[0];
+}


### PR DESCRIPTION
Inspired by: https://github.com/bazelbuild/rules_python/commit/96621391e7e8861eb448fb94b49aa1fcb9f45ba7, https://github.com/bazelbuild/rules_go/commit/fd8c0415054c923e62000417121dfd640c3cc14e

It seems like the `packages/runfiles/tests` have not been run for quite some time and can't be run in their current form. I've added those tests rules_js in https://github.com/aspect-build/rules_js/pull/1895 and I've been testing there where tests were failing with bzlmod which this PR fixes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #3714


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

