### PR TITLE
fix(runfiles): @bazel/runfiles usage with non-bzlmod repos

### DIFF
--- a/packages/runfiles/runfiles.ts
+++ b/packages/runfiles/runfiles.ts
@@ -168,7 +168,7 @@ export class Runfiles {
       // If the repository mappings were loaded ensure the source repository is valid.
       if (!(sourceRepo in this.repoMappings)) {
         throw new Error(
-          `source repository ${sourceRepo} not found in repo mappings: ${JSON.stringify(
+          `source repository "${sourceRepo}" not found in repo mappings: ${JSON.stringify(
             this.repoMappings,
             null,
             2,
@@ -181,7 +181,7 @@ export class Runfiles {
     if (result) {
       return result;
     }
-    const e = new Error(`could not resolve module ${modulePath}`);
+    const e = new Error(`could not resolve module "${modulePath}" from repository "${sourceRepo}"`);
     (e as any).code = 'MODULE_NOT_FOUND';
     throw e;
   }

--- a/packages/runfiles/runfiles.ts
+++ b/packages/runfiles/runfiles.ts
@@ -129,9 +129,9 @@ export class Runfiles {
     if (!fs.existsSync(repoMappingPath)) {
       // The repo mapping manifest only exists with Bzlmod, so it's not an
       // error if it's missing. Since any repository name not contained in the
-      // mapping is assumed to be already canonical, an empty map is
-      // equivalent to not applying any mapping.
-      return Object.create(null);
+      // mapping is assumed to be already canonical, no map is equivalent to
+      // not applying any mapping.
+      return undefined;
     }
 
     const repoMappings: RepoMappings = Object.create(null);


### PR DESCRIPTION
When in non-bzlmod and no `_repo_mapping` file exists the logic repo mapping logic should have no side-effects and should take the same code path as before https://github.com/bazel-contrib/rules_nodejs/commit/21b56da9f20c9c5e8b8c1ac19052f1f7cc7b5920