### PR TITLE
fix: remove use of incompatible_use_toolchain_transition

### DIFF
--- a/nodejs/private/nodejs_toolchains_repo.bzl
+++ b/nodejs/private/nodejs_toolchains_repo.bzl
@@ -83,7 +83,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@rules_nodejs//nodejs:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     repository_ctx.file("defs.bzl", starlark_content)


### PR DESCRIPTION
As documented at https://bazel.build/rules/lib/globals/bzl.html#rule:

    incompatible_use_toolchain_transition
    bool; default is False
    Deprecated, this is no longer in use and should be removed.

According to https://github.com/bazelbuild/bazel/pull/14049, this feature was enabled by default back in 2021.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
`rule()` is called with `incompatible_use_toolchain_transition = True`. This argument is a no-op right now, because Bazel merely provides a placeholder for this option. However, having this argument in place would cause breakages if the Bazel team decides to remove this option altogether.

## What is the new behavior?
We call it without this argument. This does not cause any noticeable differences.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

