### PR TITLE
fix: update update-nodejs-versions.js to include Node.js 24

### DIFF
--- a/scripts/update-nodejs-versions.js
+++ b/scripts/update-nodejs-versions.js
@@ -5,7 +5,7 @@
 const https = require("https");
 
 const MIN_VERSION = [8, 0, 0];
-const MAX_VERSION = [22, 99, 99];
+const MAX_VERSION = [24, 99, 99];
 
 const REPOSITORY_TYPES = {
   "darwin-arm64.tar.gz": "darwin_arm64",


### PR DESCRIPTION
Node.js is currently the latest version of Node.js.
