### PR TITLE
fix: update broken registry.bazel.build/docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ See the 5.x branch for the prior state of the repo.
 
 ## Documentation
 
-See the docs/ folder, and generated API docs on https://registry.bazel.build/docs/rules_nodejs
+See the docs/ folder, and generated API docs on https://registry.bazel.build/modules/rules_nodejs/latest/docs


### PR DESCRIPTION
## Summary

The `registry.bazel.build/docs/<name>` URL pattern returns 404 and is no longer valid.

The correct URL format is now `registry.bazel.build/modules/<name>/latest/docs`.

This was identified across multiple Bazel rule repositories — see https://github.com/hermeticbuild/rules_rs/pull/235 for the original fix.

## Changes

Updated all occurrences of the broken `/docs/<name>` URL pattern to the new `/modules/<name>/latest/docs` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
